### PR TITLE
Retarget Okapi operation to use new mod-codex-mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-search
 
+## 1.1.0 (IN PROGRESS)
+
+* Retarget Okapi operation to use new mod-codex-mock, not inventory; and to depend on Okapi interface `codex` v1.0. Fixes UISE-19.
+
 ## [1.0.0](https://github.com/folio-org/ui-search/tree/v1.0.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v0.0.2...v1.0.0)
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "hasSettings": false,
     "queryResource": "query",
     "okapiInterfaces": {
+      "codex": "1.0"
     },
     "permissionSets": [
       {

--- a/src/Search.js
+++ b/src/Search.js
@@ -30,8 +30,8 @@ class Search extends React.Component {
     query: { initialValue: {} },
     records: {
       type: 'okapi',
-      records: 'items',
-      path: 'inventory/items',
+      records: 'instances',
+      path: 'codex-instances',
       recordsRequired: '%{resultCount}',
       perRequest: 30,
       GET: {


### PR DESCRIPTION
This replaces the old use of the inventory API.

We now declare a dependency on Okapi interface `codex` v1.0.

Fixes UISE-19.