### PR TITLE
Change app name to "Codex Search".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change history for ui-search
 
+* Change app name to "Codex Search". Applies in the application list in the Stripes menu-bar, within the application itself, and in the top-level route `codexsearch`. Fixes UISE-23.
+
 ## [1.1.0](https://github.com/folio-org/ui-search/tree/v1.1.0) (2017-12-05)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.0.0...v1.1.0)
 

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "main": "src/index.js",
   "stripes": {
     "type": "app",
-    "displayName": "Search",
-    "route": "/search",
-    "home": "/search?sort=title",
+    "displayName": "Codex Search",
+    "route": "/codexsearch",
+    "home": "/codexsearch?sort=title",
     "hasSettings": false,
     "queryResource": "query",
     "okapiInterfaces": {
@@ -24,7 +24,7 @@
     "permissionSets": [
       {
         "permissionName": "module.search.enabled",
-        "displayName": "UI: Search module is enabled",
+        "displayName": "UI: Codex Search module is enabled",
         "visible": true
       }
     ],


### PR DESCRIPTION
Applies in the application list in the Stripes menu-bar, within the
application itself, and in the top-level route `codexsearch`.

Fixes UISE-23.