### PR TITLE
Display source-type icons instead of 'local', 'kb'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Change app name to "Codex Search". Applies in the application list in the Stripes menu-bar, within the application itself, and in the top-level route `codexsearch`. Fixes UISE-23.
 * New document, [the Codex contract](doc/codex-contract.md), which admittedly sounds like a Dan Brown book. Fixes UISE-28.
 * Dummy up the package file to provide an example of app metadata bundle. Fixes UISE-29, towards STCOR-117.
+* Display source-type icons instead of 'local', 'kb'. Fixes UISE-6.
 
 ## [1.1.0](https://github.com/folio-org/ui-search/tree/v1.1.0) (2017-12-05)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.0.0...v1.1.0)

--- a/src/Search.js
+++ b/src/Search.js
@@ -5,6 +5,8 @@ import makeQueryFunction from '@folio/stripes-components/util/makeQueryFunction'
 import SearchAndSort from '@folio/stripes-smart-components/lib/SearchAndSort';
 import ViewRecord from './ViewRecord';
 import packageInfo from '../package';
+import localIcon from '../icons/local-source.svg';
+import kbIcon from '../icons/generic.svg';
 
 const filterConfig = [
   {
@@ -49,6 +51,12 @@ class Search extends React.Component {
 
   render() {
     const resultsFormatter = {
+      source: x => (<img
+        src={x.source === 'local' ? localIcon : kbIcon}
+        alt={x.source}
+        height="18"
+        width="18"
+      />),
       contributor: x => (x.contributor || []).map(y => `'${y.name}'`).join(', '),
     };
 
@@ -63,7 +71,7 @@ class Search extends React.Component {
       initialResultCount={30}
       resultCountIncrement={30}
       viewRecordComponent={ViewRecord}
-      visibleColumns={['id', 'source', 'title', 'contributor']}
+      visibleColumns={['source', 'title', 'contributor']}
       resultsFormatter={resultsFormatter}
       viewRecordPerms="users.item.get"
       disableRecordCreation


### PR DESCRIPTION
Fixes UISE-6, more or less. The problem is that, for reasons I do not
yet understand, the icon appears in a very wide field. I'll commit it
in its present state so I can ask @JohnC to take a look.