### PR TITLE
Set all column widths

### DIFF
--- a/src/Search.js
+++ b/src/Search.js
@@ -72,7 +72,7 @@ class Search extends React.Component {
       resultCountIncrement={30}
       viewRecordComponent={ViewRecord}
       visibleColumns={['source', 'title', 'contributor']}
-      columnWidths={{ source: '60px' }}
+      columnWidths={{ source: '10%', title: '40%', contributor: '50%' }}
       resultsFormatter={resultsFormatter}
       viewRecordPerms="users.item.get"
       disableRecordCreation


### PR DESCRIPTION
I don't like this -- I want `<MultiColumnList>` to Just Work when one
of its members include an `<img>`, just as it does when they are all
plain text. But until STCOM-169 is fixed, we need this workaround.