### PR TITLE
Default query is now Codex profile-compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Set value of query-index from the `qindex` URL query parameter. Fixes UISE-38.
 * Grey out unavailable indexes instead of omitting them entirely. Fixes UISE-40.
 * Implement correct filters for local-only targets. Fixes UISE-3.
+* Default query for local-only mode is now Codex profile-compliant. Fixes UISE-43.
 
 ## [1.1.0](https://github.com/folio-org/ui-search/tree/v1.1.0) (2017-12-05)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.0.0...v1.1.0)

--- a/src/Search.js
+++ b/src/Search.js
@@ -113,7 +113,7 @@ class Search extends React.Component {
         params: {
           query: makeQueryFunction(
             'cql.allRecords=1',
-            'title="$QUERY*" or altTitle="$QUERY*" or contributor.name="$QUERY*" or publisher="$QUERY*"',
+            'title="$QUERY*" or identifier="$QUERY*" or contributor="$QUERY*" or publisher="$QUERY*"',
             { Title: 'title', Contributor: 'contributor.name' },
             filterConfig,
           ),


### PR DESCRIPTION
It previously used non-compliant indexes `altTitle` and `contributor.name`.

It now generates queries like
```
(title="a*" or identifier="a*" or contributor="a*" or publisher="a*") and source="local" sortby title
```
This uses four indexes, all of them specified as supported in the Codex in https://github.com/folio-org/raml/blob/master/schemas/codex/codex_instance_cqlschema.json

(Note that this search is only available when the Ebsco KB is deselected, so it's never asked to do an OR operation that it can't handle.)