### PR TITLE
Upgrade dependencies for new Codex WSAPI

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "hasSettings": false,
     "queryResource": "query",
     "okapiInterfaces": {
-      "codex": "2.0"
+      "codex": "3.0"
     },
     "permissionSets": [
       {
@@ -102,7 +102,7 @@
     "uuid": "^3.0.1"
   },
   "peerDependencies": {
-    "@folio/stripes-connect": "^3.0.0",
+    "@folio/stripes-connect": "^3.1.0",
     "@folio/stripes-core": "^2.8.0",
     "@folio/stripes-logger": "^0.0.2"
   }


### PR DESCRIPTION
* `okapiInterfaces.codex` from 2.0 to 3.0.
* stripes-connect from 3.0.0 to  ^3.1.0".

Related to STCON-56.