### PR TITLE
Limit to a single sort-key. Fixes UISE-47.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Grey out unavailable indexes instead of omitting them entirely. Fixes UISE-40.
 * Implement correct filters for local-only targets. Fixes UISE-3.
 * Default query for local-only mode is now Codex profile-compliant. Fixes UISE-43.
+* When starting the Codex Search UI, do not search for `cql.allRecords=1`. Fixes UISE-41.
 
 ## [1.1.0](https://github.com/folio-org/ui-search/tree/v1.1.0) (2017-12-05)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.0.0...v1.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Implement correct filters for local-only targets. Fixes UISE-3.
 * Default query for local-only mode is now Codex profile-compliant. Fixes UISE-43.
 * When starting the Codex Search UI, do not search for `cql.allRecords=1`. Fixes UISE-41.
+* Limit to a single sort-key. Avoids causing problems for mod-ebsco-ekb, and fixes UISE-47.
 
 ## [1.1.0](https://github.com/folio-org/ui-search/tree/v1.1.0) (2017-12-05)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.0.0...v1.1.0)

--- a/src/Search.js
+++ b/src/Search.js
@@ -116,6 +116,7 @@ class Search extends React.Component {
             'title="$QUERY*" or identifier="$QUERY*" or contributor="$QUERY*" or publisher="$QUERY*"',
             { Title: 'title', Contributor: 'contributor.name' },
             filterConfig,
+            true,
           ),
         },
         staticFallback: { params: {} },

--- a/src/Search.js
+++ b/src/Search.js
@@ -190,6 +190,7 @@ class Search extends React.Component {
       searchableIndexes={searchableIndexes}
       selectedIndex={_.get(this.props.resources.query, 'qindex')}
       onChangeIndex={this.onChangeIndex}
+      maxSortKeys={1}
       filterConfig={filterConfig}
       disableFilters={disableFilters}
       initialResultCount={30}


### PR DESCRIPTION
I accidentally re-used the UISE-41 branch to fix UISE-47, but I do not care.