### PR TITLE
Prevent selection of query-index not supported by source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Default query for local-only mode is now Codex profile-compliant. Fixes UISE-43.
 * When starting the Codex Search UI, do not search for `cql.allRecords=1`. Fixes UISE-41.
 * Limit to a single sort-key. Avoids causing problems for mod-ebsco-ekb, and fixes UISE-47.
+* Prevent selection of query-index not supported by source. Fixes UISE-46.
 
 ## [1.1.0](https://github.com/folio-org/ui-search/tree/v1.1.0) (2017-12-05)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.0.0...v1.1.0)

--- a/src/Search.js
+++ b/src/Search.js
@@ -158,11 +158,9 @@ class Search extends React.Component {
   }
 
   filtersHaveChanged = (newFilters) => {
-    console.log('filters have changed to ', newFilters);
     if (newFilters['source.Local'] && !newFilters['source.Knowledge Base']) return;
 
     const qindex = _.get(this.props.resources.query, 'qindex') || '';
-    console.log(`Knowledge Base included; checking whether qindex '${qindex}' is supported`);
     let indexObject;
     for (const index of availableIndexes) {
       if (index.value === qindex) {
@@ -171,27 +169,16 @@ class Search extends React.Component {
       }
     }
 
-    if (!indexObject) {
-      console.log(`cannot find qindex '${qindex}' in availableIndexes`);
-      return;
-    }
+    if (!indexObject) return;
+    if (!indexObject.localOnly) return;
 
-    if (!indexObject.localOnly) {
-      console.log(`qindex '${qindex}' is OK outside of local inventory`);
-      return;
-    }
-
-    console.log(`qindex '${qindex}' cannot be used: replacing`);
     // Find first available index that is not localOnly
     for (const index of availableIndexes) {
       if (!index.localOnly) {
-        console.log(`replacing qindex '${qindex}' with '${index.value}'`);
         this.props.mutator.query.update({ qindex: index.value });
         return;
       }
     }
-
-    console.log('Could not find a non-disabled value for qindex');
   }
 
   render() {

--- a/src/Search.js
+++ b/src/Search.js
@@ -81,6 +81,21 @@ const filterConfig = [
   },
 ];
 
+
+const availableIndexes = [
+  { label: '---', value: '', localOnly: true },
+  { label: 'ID', value: 'id' },
+  { label: 'Title', value: 'title' },
+  { label: 'Identifier', value: 'identifier', localOnly: true },
+  { label: 'ISBN', value: 'identifier/type=isbn' },
+  { label: 'ISSN', value: 'identifier/type=issn' },
+  { label: 'Contributor', value: 'contributor', localOnly: true },
+  { label: 'Subject', value: 'subject', localOnly: true },
+  { label: 'Classification', value: 'classification', localOnly: true },
+  { label: 'Publisher', value: 'publisher' },
+];
+
+
 class Search extends React.Component {
   static propTypes = {
     resources: PropTypes.shape({
@@ -124,11 +139,59 @@ class Search extends React.Component {
     },
   });
 
+  componentWillMount() {
+    // XXX Hardwired knowledge here of the default filters. Should parse it out of initialPath
+    this.filtersHaveChanged({});
+    // The change to the anointed resource in filtersHaveChanged()
+    // does not, for some reason, get reflected in the URL: perhaps
+    // thish happens too early in the lifecycle, before the
+    // anointedness has been established. But this doesn't matter,
+    // because no search is executed until a query is entered, and at
+    // that moment the relevant qindex change also enters the URL.
+  }
+
   onChangeIndex = (e) => {
     const qindex = e.target.value;
     const logger = this.props.stripes.logger;
     logger.log('action', `changed query-index to '${qindex}'`);
     this.props.mutator.query.update({ qindex });
+  }
+
+  filtersHaveChanged = (newFilters) => {
+    console.log('filters have changed to ', newFilters);
+    if (newFilters['source.Local'] && !newFilters['source.Knowledge Base']) return;
+
+    const qindex = _.get(this.props.resources.query, 'qindex') || '';
+    console.log(`Knowledge Base included; checking whether qindex '${qindex}' is supported`);
+    let indexObject;
+    for (const index of availableIndexes) {
+      if (index.value === qindex) {
+        indexObject = index;
+        break;
+      }
+    }
+
+    if (!indexObject) {
+      console.log(`cannot find qindex '${qindex}' in availableIndexes`);
+      return;
+    }
+
+    if (!indexObject.localOnly) {
+      console.log(`qindex '${qindex}' is OK outside of local inventory`);
+      return;
+    }
+
+    console.log(`qindex '${qindex}' cannot be used: replacing`);
+    // Find first available index that is not localOnly
+    for (const index of availableIndexes) {
+      if (!index.localOnly) {
+        console.log(`replacing qindex '${qindex}' with '${index.value}'`);
+        this.props.mutator.query.update({ qindex: index.value });
+        return;
+      }
+    }
+
+    console.log('Could not find a non-disabled value for qindex');
   }
 
   render() {
@@ -142,6 +205,7 @@ class Search extends React.Component {
       contributor: x => (x.contributor || []).map(y => `'${y.name}'`).join(', '),
     };
 
+    const searchableIndexes = availableIndexes.map(index => Object.assign({}, index));
     const filters = _.get(this.props.resources, ['query', 'filters']);
     // possible values:
     //  undefined
@@ -149,24 +213,10 @@ class Search extends React.Component {
     //  'source.Local,source.Knowledge Base'
     //  'source.Knowledge Base'
     //  ''
-
-    const searchableIndexes = Object.assign([], [
-      { label: '---', value: '' },
-      { label: 'ID', value: 'id' },
-      { label: 'Title', value: 'title' },
-      { label: 'Identifier', value: 'identifier' },
-      { label: 'ISBN', value: 'identifier/type=isbn' },
-      { label: 'ISSN', value: 'identifier/type=issn' },
-      { label: 'Contributor', value: 'contributor' },
-      { label: 'Subject', value: 'subject' },
-      { label: 'Classification', value: 'classification' },
-      { label: 'Publisher', value: 'publisher' },
-    ]);
-
     if (filters === undefined || filters === '' ||
         filters.match('source.Knowledge Base')) {
-      for (const i of [0, 3, 6, 7, 8]) {
-        searchableIndexes[i].disabled = true;
+      for (const index of searchableIndexes) {
+        if (index.localOnly) index.disabled = true;
       }
     }
 
@@ -193,6 +243,7 @@ class Search extends React.Component {
       maxSortKeys={1}
       filterConfig={filterConfig}
       disableFilters={disableFilters}
+      filterChangeCallback={this.filtersHaveChanged}
       initialResultCount={30}
       resultCountIncrement={30}
       viewRecordComponent={ViewRecord}


### PR DESCRIPTION
This works by means of a `filterChangeCallback` (see STSMACOM-47). Since this has to share knowledge with `render` of what query indexes exist and which are limited to local sources only, the representation of that information has changed, and moved out of `render` to the top level.

Fixes UISE-46.
