### PR TITLE
More robust analysis of which sources are selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Enable both _FOLIO ID_ search and _Identifier_ search in EBSCO KB. Fixes UISE-49.
 * Upgrade `eslint` dependency to v4.7.2, allowing `eslint-config-stripes` v1.0.0 to work. Fixes UISE-65.
 * Add completely trivial testing framework (enabling real tests to follow). Fixes UISE-61.
+* More robust analysis of which sources are selected, so local-only index are disabled under correct circumstances. Fixes UISE-64.
 
 ## [1.1.0](https://github.com/folio-org/ui-search/tree/v1.1.0) (2017-12-05)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.0.0...v1.1.0)

--- a/src/Search.js
+++ b/src/Search.js
@@ -5,6 +5,7 @@ import queryString from 'query-string';
 import { withRouter } from 'react-router';
 import makeQueryFunction from '@folio/stripes-components/util/makeQueryFunction';
 import SearchAndSort from '@folio/stripes-smart-components/lib/SearchAndSort';
+import { filterState } from '@folio/stripes-components/lib/FilterGroups';
 import ViewRecord from './ViewRecord';
 import packageInfo from '../package';
 import localIcon from '../icons/local-source.svg';
@@ -244,14 +245,8 @@ class Search extends React.Component {
 
     const searchableIndexes = availableIndexes.map(index => Object.assign({}, index));
     const filters = _.get(this.props.resources, ['query', 'filters']);
-    // possible values:
-    //  undefined
-    //  'source.Local'
-    //  'source.Local,source.Knowledge Base'
-    //  'source.Knowledge Base'
-    //  ''
-    if (filters === undefined || filters === '' ||
-        filters.match('source.Knowledge Base')) {
+    const filterKeys = filterState(filters);
+    if (!filterKeys['source.Local'] || filterKeys['source.Knowledge Base']) {
       for (const index of searchableIndexes) {
         if (index.localOnly) index.disabled = true;
       }


### PR DESCRIPTION
We now ignore the settings of non-source filters, so that then no
sources are selected, the query-index dropdown correctly disables the
local-only indexes.

Fixes UISE-64.