### PR TITLE
Map filters when transitioning to Inventory app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Add the very beginnings of a unit-test suite. Fixes UISE-61.
 * No more strange redirects after following a link into Inventory or eHoldings! Fixes UISE-56 and UISE-26.
 * Initially selected index is "Title", not "ID". Fixes UISE-57.
+* When linking into the Inventory app, map filters. Fixes UISE-67.
 
 ## [1.1.0](https://github.com/folio-org/ui-search/tree/v1.1.0) (2017-12-05)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.0.0...v1.1.0)

--- a/src/Search.js
+++ b/src/Search.js
@@ -184,11 +184,17 @@ class Search extends React.Component {
       obj.searchType = 'titles';
       obj.q = _.get(this.props.resources, ['query', 'query']);
       obj.query = null;
+      // TODO: reseting filters is a temp solution until
+      // https://issues.folio.org/browse/UISE-67 is fixed
+      obj.filters = '';
     } else if (record.source === 'local') {
       obj._path = `/inventory/view/${record.id}`;
       obj.searchType = null;
       obj.q = null;
       // The 'query' parameter should already be correct
+      // TODO: reseting filters is a temp solution until
+      // https://issues.folio.org/browse/UISE-67 is fixed
+      obj.filters = '';
     } else {
       logger.log('action', `unsupported source '${record.source}': doing nothing`);
       return true;
@@ -196,9 +202,6 @@ class Search extends React.Component {
 
     logger.log('action', `clicked ${record.id}, jumping to '${record.source}' version with obj`, obj);
 
-    // TODO: reseting filters is a temp solution until
-    // https://issues.folio.org/browse/UISE-67 is fixed
-    obj.filters = '';
     this.props.mutator.query.update(obj);
     return false;
   }

--- a/src/Search.js
+++ b/src/Search.js
@@ -7,6 +7,7 @@ import makeQueryFunction from '@folio/stripes-components/util/makeQueryFunction'
 import SearchAndSort from '@folio/stripes-smart-components/lib/SearchAndSort';
 import { filterState } from '@folio/stripes-components/lib/FilterGroups';
 import ViewRecord from './ViewRecord';
+import redirectParams from './redirectParams';
 import packageInfo from '../package';
 import localIcon from '../icons/local-source.svg';
 import kbIcon from '../icons/generic.svg';
@@ -178,31 +179,14 @@ class Search extends React.Component {
   onSelectRow = (e, record) => {
     const logger = this.props.stripes.logger;
 
-    const obj = {};
-    if (record.source === 'kb') {
-      obj._path = `/eholdings/titles/${record.id}`;
-      obj.searchType = 'titles';
-      obj.q = _.get(this.props.resources, ['query', 'query']);
-      obj.query = null;
-      // TODO: reseting filters is a temp solution until
-      // https://issues.folio.org/browse/UISE-67 is fixed
-      obj.filters = '';
-    } else if (record.source === 'local') {
-      obj._path = `/inventory/view/${record.id}`;
-      obj.searchType = null;
-      obj.q = null;
-      // The 'query' parameter should already be correct
-      // TODO: reseting filters is a temp solution until
-      // https://issues.folio.org/browse/UISE-67 is fixed
-      obj.filters = '';
+    const obj = redirectParams(record, this.props.resources);
+    logger.log('action', `clicked ${record.id}, jumping to '${record.source}' version with obj`, obj);
+    if (obj) {
+      this.props.mutator.query.update(obj);
     } else {
       logger.log('action', `unsupported source '${record.source}': doing nothing`);
-      return true;
     }
 
-    logger.log('action', `clicked ${record.id}, jumping to '${record.source}' version with obj`, obj);
-
-    this.props.mutator.query.update(obj);
     return false;
   }
 

--- a/src/redirectParams.js
+++ b/src/redirectParams.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 function redirectParamsKB(record, resources) {
   const obj = {
     _path: `/eholdings/titles/${record.id}`,
+    qindex: null,
     searchType: 'titles',
     q: _.get(resources, ['query', 'query']),
     query: null,
@@ -18,8 +19,7 @@ function redirectParamsKB(record, resources) {
 function redirectParamsLocal(record, _resources) {
   const obj = {
     _path: `/inventory/view/${record.id}`,
-    searchType: null,
-    q: null,
+    qindex: null,
     // The 'query' parameter takes the same value in inventory as here
   };
 

--- a/src/redirectParams.js
+++ b/src/redirectParams.js
@@ -1,26 +1,34 @@
 import _ from 'lodash';
 
+function redirectParamsKB(record, resources) {
+  const obj = {};
+  obj._path = `/eholdings/titles/${record.id}`;
+  obj.searchType = 'titles';
+  obj.q = _.get(resources, ['query', 'query']);
+  obj.query = null;
+  // TODO: reseting filters is a temp solution until
+  // https://issues.folio.org/browse/UISE-67 is fixed
+  obj.filters = '';
+  return obj;
+}
+
+function redirectParamsLocal(record, _resources) {
+  const obj = {};
+  obj._path = `/inventory/view/${record.id}`;
+  obj.searchType = null;
+  obj.q = null;
+  // The 'query' parameter should already be correct
+  // TODO: reseting filters is a temp solution until
+  // https://issues.folio.org/browse/UISE-67 is fixed
+  obj.filters = '';
+  return obj;
+}
+
 function redirectParams(record, resources) {
   if (record.source === 'kb') {
-    const obj = {};
-    obj._path = `/eholdings/titles/${record.id}`;
-    obj.searchType = 'titles';
-    obj.q = _.get(resources, ['query', 'query']);
-    obj.query = null;
-    // TODO: reseting filters is a temp solution until
-    // https://issues.folio.org/browse/UISE-67 is fixed
-    obj.filters = '';
-    return obj;
+    return redirectParamsKB(record, resources);
   } else if (record.source === 'local') {
-    const obj = {};
-    obj._path = `/inventory/view/${record.id}`;
-    obj.searchType = null;
-    obj.q = null;
-    // The 'query' parameter should already be correct
-    // TODO: reseting filters is a temp solution until
-    // https://issues.folio.org/browse/UISE-67 is fixed
-    obj.filters = '';
-    return obj;
+    return redirectParamsLocal(record, resources);
   }
   return null;
 }

--- a/src/redirectParams.js
+++ b/src/redirectParams.js
@@ -1,4 +1,48 @@
 import _ from 'lodash';
+import { filterState } from '@folio/stripes-components/lib/FilterGroups';
+
+
+// 'filters' is a comma-separated list of 'FILTER.VALUE'
+//  e.g. 'available.Available online,source.Local,type.Books,type.eBooks'
+//
+// 'mapping' is an object specifying how to map filters:
+//  keys are 'name' elements of objects in filterConfig
+//  values may be:
+//   null (when the filter has no equivalent in the destination app and should be discarded)
+//   otherwise an object with keys:
+//    name: the name of the filter in the destination app
+//    values: may be either
+//     null (when the values are the same in the destination app)
+//     or a map of values in Codex search to corresponding values in destination app
+//
+function mapFilters(filters, mapping) {
+  const filterKeys = filterState(filters);
+  const acc = [];
+
+  Object.keys(filterKeys).forEach((fullName) => {
+    const [groupName, fieldName] = fullName.split('.');
+    console.log(`considering '${groupName}' filter '${fieldName}'`);
+    const group = mapping[groupName];
+    if (group) {
+      if (!group.values) {
+        // The values do not need mapping
+        const mapped = `${group.name}.${fieldName}`;
+        acc.push(mapped);
+      } else {
+        const mappedVal = group.values[fieldName];
+        if (mappedVal) {
+          const mapped = `${group.name}.${mappedVal}`;
+          acc.push(mapped);
+        }
+      }
+    }
+  });
+
+  const res = acc.join(',');
+  console.log(`mapped '${filters}' -> '${res}'`);
+  return res;
+}
+
 
 function redirectParamsKB(record, resources) {
   const obj = {
@@ -7,28 +51,62 @@ function redirectParamsKB(record, resources) {
     searchType: 'titles',
     q: _.get(resources, ['query', 'query']),
     query: null,
+    filters: mapFilters(_.get(resources, ['query', 'filters']), {
+      // add config
+    }),
   };
-
-  // TODO: reseting filters is a temp solution until
-  // https://issues.folio.org/browse/UISE-67 is fixed
-  obj.filters = '';
 
   return obj;
 }
 
-function redirectParamsLocal(record, _resources) {
+
+function redirectParamsLocal(record, resources) {
   const obj = {
     _path: `/inventory/view/${record.id}`,
     qindex: null,
     // The 'query' parameter takes the same value in inventory as here
+    filters: mapFilters(_.get(resources, ['query', 'filters']), {
+      source: null,
+      type: {
+        name: 'resource',
+        values: {
+          /* eslint-disable quote-props */
+          'Audio': 'Music (Audio)',
+          'Audiobooks': null,
+          'Books': 'Books',
+          'Bookseries': null,
+          'Databases': null,
+          'eBooks': 'eBooks',
+          'Kits': 'Kits',
+          'Maps': 'Maps',
+          'Music': 'Music (Scores)',
+          'Newspapers': null,
+          'Newsletters': null,
+          'Periodicals': 'Serials',
+          'Posters': 'Charts Posters',
+          'Reports': null,
+          'Proceedings': null,
+          'Thesis and Dissertation': 'Theses',
+          'Unspecified': null,
+          'Video': 'Videorecording',
+          'Web Resources': 'Web Resources',
+        },
+      },
+      location: {
+        name: 'location',
+        values: null,
+      },
+      available: null,
+      lang: {
+        name: 'language',
+        values: null,
+      },
+    }),
   };
-
-  // TODO: reseting filters is a temp solution until
-  // https://issues.folio.org/browse/UISE-67 is fixed
-  obj.filters = '';
 
   return obj;
 }
+
 
 function redirectParams(record, resources) {
   if (record.source === 'kb') {
@@ -39,5 +117,6 @@ function redirectParams(record, resources) {
     return null;
   }
 }
+
 
 export default redirectParams;

--- a/src/redirectParams.js
+++ b/src/redirectParams.js
@@ -38,7 +38,7 @@ function mapFilters(filters, mapping) {
   });
 
   const res = acc.join(',');
-  console.log(`mapped '${filters}' -> '${res}'`);
+  // console.log(`mapped '${filters}' -> '${res}'`);
   return res;
 }
 
@@ -51,7 +51,11 @@ function redirectParamsKB(record, resources) {
     q: _.get(resources, ['query', 'query']),
     query: null,
     filters: mapFilters(_.get(resources, ['query', 'filters']), {
-      // add config
+      // We would like to add a configuration for this, but it turns
+      // out that the eHoldings app represents its filters in a
+      // radically different way from mainstream Stripes apps, and in
+      // particular has no state representation in the URL. So there
+      // is nothing for us to map to.
     }),
   };
 

--- a/src/redirectParams.js
+++ b/src/redirectParams.js
@@ -29,8 +29,9 @@ function redirectParams(record, resources) {
     return redirectParamsKB(record, resources);
   } else if (record.source === 'local') {
     return redirectParamsLocal(record, resources);
+  } else {
+    return null;
   }
-  return null;
 }
 
 export default redirectParams;

--- a/src/redirectParams.js
+++ b/src/redirectParams.js
@@ -21,7 +21,6 @@ function mapFilters(filters, mapping) {
 
   Object.keys(filterKeys).forEach((fullName) => {
     const [groupName, fieldName] = fullName.split('.');
-    console.log(`considering '${groupName}' filter '${fieldName}'`);
     const group = mapping[groupName];
     if (group) {
       if (!group.values) {

--- a/src/redirectParams.js
+++ b/src/redirectParams.js
@@ -1,9 +1,8 @@
 import _ from 'lodash';
 
 function redirectParams(record, resources) {
-  const obj = {};
-
   if (record.source === 'kb') {
+    const obj = {};
     obj._path = `/eholdings/titles/${record.id}`;
     obj.searchType = 'titles';
     obj.q = _.get(resources, ['query', 'query']);
@@ -13,6 +12,7 @@ function redirectParams(record, resources) {
     obj.filters = '';
     return obj;
   } else if (record.source === 'local') {
+    const obj = {};
     obj._path = `/inventory/view/${record.id}`;
     obj.searchType = null;
     obj.q = null;

--- a/src/redirectParams.js
+++ b/src/redirectParams.js
@@ -11,6 +11,7 @@ function redirectParams(record, resources) {
     // TODO: reseting filters is a temp solution until
     // https://issues.folio.org/browse/UISE-67 is fixed
     obj.filters = '';
+    return obj;
   } else if (record.source === 'local') {
     obj._path = `/inventory/view/${record.id}`;
     obj.searchType = null;
@@ -19,10 +20,9 @@ function redirectParams(record, resources) {
     // TODO: reseting filters is a temp solution until
     // https://issues.folio.org/browse/UISE-67 is fixed
     obj.filters = '';
-  } else {
-    return null;
+    return obj;
   }
-  return obj;
+  return null;
 }
 
 export default redirectParams;

--- a/src/redirectParams.js
+++ b/src/redirectParams.js
@@ -1,0 +1,28 @@
+import _ from 'lodash';
+
+function redirectParams(record, resources) {
+  const obj = {};
+
+  if (record.source === 'kb') {
+    obj._path = `/eholdings/titles/${record.id}`;
+    obj.searchType = 'titles';
+    obj.q = _.get(resources, ['query', 'query']);
+    obj.query = null;
+    // TODO: reseting filters is a temp solution until
+    // https://issues.folio.org/browse/UISE-67 is fixed
+    obj.filters = '';
+  } else if (record.source === 'local') {
+    obj._path = `/inventory/view/${record.id}`;
+    obj.searchType = null;
+    obj.q = null;
+    // The 'query' parameter should already be correct
+    // TODO: reseting filters is a temp solution until
+    // https://issues.folio.org/browse/UISE-67 is fixed
+    obj.filters = '';
+  } else {
+    return null;
+  }
+  return obj;
+}
+
+export default redirectParams;

--- a/src/redirectParams.js
+++ b/src/redirectParams.js
@@ -1,26 +1,32 @@
 import _ from 'lodash';
 
 function redirectParamsKB(record, resources) {
-  const obj = {};
-  obj._path = `/eholdings/titles/${record.id}`;
-  obj.searchType = 'titles';
-  obj.q = _.get(resources, ['query', 'query']);
-  obj.query = null;
+  const obj = {
+    _path: `/eholdings/titles/${record.id}`,
+    searchType: 'titles',
+    q: _.get(resources, ['query', 'query']),
+    query: null,
+  };
+
   // TODO: reseting filters is a temp solution until
   // https://issues.folio.org/browse/UISE-67 is fixed
   obj.filters = '';
+
   return obj;
 }
 
 function redirectParamsLocal(record, _resources) {
-  const obj = {};
-  obj._path = `/inventory/view/${record.id}`;
-  obj.searchType = null;
-  obj.q = null;
-  // The 'query' parameter should already be correct
+  const obj = {
+    _path: `/inventory/view/${record.id}`,
+    searchType: null,
+    q: null,
+    // The 'query' parameter takes the same value in inventory as here
+  };
+
   // TODO: reseting filters is a temp solution until
   // https://issues.folio.org/browse/UISE-67 is fixed
   obj.filters = '';
+
   return obj;
 }
 


### PR DESCRIPTION
(We would like to also do this for the eHoldings app, but it turns out that this represents its filters in a radically different way from mainstream Stripes apps, and in particular has no state representation in the URL. So there is nothing for us to map to.)

Fixes UISE-67.