### PR TITLE
When clearing the search, the record-display area clears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * "Search all fields" query-index can be selected. Fixes UISE-72.
 * Pass packageInfo to SearchAndSort; it's simpler. Refs STSMACOM-64. Available after v1.1.1.
 * Include text labels along with record-source icons. Fixes UISE-58.
+* When clearing the search, the record-display area clears. Fixes UISE-48.
 
 ## [1.1.0](https://github.com/folio-org/ui-search/tree/v1.1.0) (2017-12-05)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.0.0...v1.1.0)

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "uuid": "^3.0.1"
   },
   "peerDependencies": {
-    "@folio/stripes-connect": "^3.1.0",
+    "@folio/stripes-connect": "^3.1.1",
     "@folio/stripes-core": "^2.9.1",
     "@folio/stripes-logger": "^0.0.2",
     "mocha": "^5.0.0",

--- a/src/Search.js
+++ b/src/Search.js
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
-import queryString from 'query-string';
 import makeQueryFunction from '@folio/stripes-components/util/makeQueryFunction';
 import SearchAndSort from '@folio/stripes-smart-components/lib/SearchAndSort';
 import { filterState } from '@folio/stripes-components/lib/FilterGroups';


### PR DESCRIPTION
Fixes UISE-48.