### PR TITLE
Add stripes serve to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "defaultPreviewWidth": "40%",
     "helpPage": "https://wiki.folio.org/pages/viewpage.action?pageId=1415393",
     "route": "/codexsearch",
-
     "home": "/codexsearch?filters=available.Available%20online&qindex=title&query=&sort=title",
     "hasSettings": false,
     "queryResource": "query",
@@ -75,18 +74,20 @@
     "libraryCredits": "This application is made possible by [the React library](https://reactjs.org/)."
   },
   "scripts": {
+    "start": "stripes serve",
     "lint": "eslint .",
     "test": "(cd ../ui-testing; env FOLIO_UI_URL=http://localhost:8080 FOLIO_UI_WAIT_TIMEOUT=10000 yarn test-module -o --run=search)"
   },
   "devDependencies": {
+    "@folio/eslint-config-stripes": "^1.1.0",
+    "@folio/stripes-cli": "^1.2.0",
     "babel-core": "^6.17.0",
     "babel-eslint": "^8.0.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",
     "babel-register": "^6.18.0",
-    "eslint": "^4.8.0",
-    "@folio/eslint-config-stripes": "^1.1.0"
+    "eslint": "^4.8.0"
   },
   "dependencies": {
     "@folio/stripes-components": "^2.0.1",


### PR DESCRIPTION
[Stripes CLI](https://github.com/folio-org/stripes-cli) provides a `serve` command that can be used to run a module by itself, without defining an entire platform to run in a `workspace`.

This is handy for:
- working on a single module
- testing a module in isolation
- cutting down the `node` process overhead of running several actively building modules in a local `webpack` server

To use (after a `yarn install`):
```
yarn start
```

By default, `http://localhost:3000` will attempt to connect to a back end at `http://localhost:9130`. To connect to a different Okapi cluster:
```
yarn start --okapi https://my-okapi-cluster.folio.org
```

[Full list of available `stripes serve` options](https://github.com/folio-org/stripes-cli/blob/master/doc/commands.md#serve-command)

Related to https://github.com/folio-org/ui-checkin/pull/51