### PR TITLE
Bump stripes-components dependency to ^3.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Use `%{query.query}` instead of `$QUERY` in makeQueryFunction template. Fixes UISE-75.
 * Ignore yarn-error.log file. Refs STRIPES-517.
 * Use `<AppIcon>` for Local/KB icons. Fixes UISE-74.
+* Bump stripes-components dependency to `^3.0.7`, pulling in the STCOM-321 regression fix, which makes ISSN searching work again. Fixes UISE-82. Available from v1.1.2.
 
 ## [1.1.0](https://github.com/folio-org/ui-search/tree/v1.1.0) (2017-12-05)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.0.0...v1.1.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/search",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Search across the Codex",
   "repository": "folio-org/ui-search",
   "publishConfig": {
@@ -90,7 +90,7 @@
     "eslint": "^4.8.0"
   },
   "dependencies": {
-    "@folio/stripes-components": "^3.0.0",
+    "@folio/stripes-components": "^3.0.7",
     "@folio/stripes-form": "^0.8.1",
     "@folio/stripes-smart-components": "^1.4.3",
     "classnames": "^2.2.5",


### PR DESCRIPTION
This pulls in the STCOM-321 regression fix, which makes ISSN searching work again.

Fixes UISE-82.

Available from v1.1.2.