### PR TITLE
remove unused dep on react-bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Ignore yarn-error.log file. Refs STRIPES-517.
 * Use `<AppIcon>` for Local/KB icons. Fixes UISE-74.
 * Bump stripes-components dependency to `^3.0.7`, pulling in the STCOM-321 regression fix, which makes ISSN searching work again. Fixes UISE-82. Available from v1.1.2.
+* Removed unused react-bootstrap dep that was pulling in an incompatible babel-runtime release. Refs FOLIO-1425.
 
 ## [1.1.0](https://github.com/folio-org/ui-search/tree/v1.1.0) (2017-12-05)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.0.0...v1.1.0)

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",
-    "react-bootstrap": "^0.31.1",
     "react-flexbox-grid": "^2.0.0",
     "react-intl": "^2.3.0",
     "react-router": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "dependencies": {
     "@folio/stripes-components": "^3.0.7",
     "@folio/stripes-form": "^0.8.1",
-    "@folio/stripes-smart-components": "^1.4.3",
+    "@folio/stripes-smart-components": "^1.4.28",
     "classnames": "^2.2.5",
     "hashcode": "^1.0.3",
     "lodash": "^4.17.4",


### PR DESCRIPTION
react-bootstrap >0.32.1 introduces a dependency on babel-runtime
^7.0.0-beta.42 that is incompatible with other modules in our system and
breaks the build. This appears to be a legacy dependency since there are
no references to it in the current codebase. Mad props to  @marcjohnson-kint
for diagnosing this.

Refs [FOLIO-1425](https://issues.folio.org/browse/FOLIO-1425)