### PR TITLE
Specify a custom search-not-yet-loaded message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@
 * Bump stripes-components dependency to `^3.0.7`, pulling in the STCOM-321 regression fix, which makes ISSN searching work again. Fixes UISE-82. Available from v1.1.2.
 * Removed unused react-bootstrap dep that was pulling in an incompatible babel-runtime release. Refs FOLIO-1425.
 * Change default search-area message not to refer to selecting filter. Fixes UISE-81. Available from v1.1.3.
-* Specify a custom search-not-yet-loaded message that does not misleadingly refer to filters. Fixes UISE-81.
 
 ## [1.1.0](https://github.com/folio-org/ui-search/tree/v1.1.0) (2017-12-05)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.0.0...v1.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
 * Ignore yarn-error.log file. Refs STRIPES-517.
 * Use `<AppIcon>` for Local/KB icons. Fixes UISE-74.
 * Bump stripes-components dependency to `^3.0.7`, pulling in the STCOM-321 regression fix, which makes ISSN searching work again. Fixes UISE-82. Available from v1.1.2.
+* Change default search-area message not to refer to selecting filter. Fixes UISE-81. Available from v1.1.3.
+* Specify a custom search-not-yet-loaded message that does not misleadingly refer to filters. Fixes UISE-81.
 
 ## [1.1.0](https://github.com/folio-org/ui-search/tree/v1.1.0) (2017-12-05)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.0.0...v1.1.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/search",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Search across the Codex",
   "repository": "folio-org/ui-search",
   "publishConfig": {
@@ -92,7 +92,7 @@
   "dependencies": {
     "@folio/stripes-components": "^3.0.7",
     "@folio/stripes-form": "^0.8.1",
-    "@folio/stripes-smart-components": "^1.4.3",
+    "@folio/stripes-smart-components": "^1.4.29",
     "classnames": "^2.2.5",
     "hashcode": "^1.0.3",
     "lodash": "^4.17.4",

--- a/src/Search.js
+++ b/src/Search.js
@@ -245,6 +245,7 @@ class Search extends React.Component {
       disableRecordCreation
       parentResources={this.props.resources}
       parentMutator={this.props.mutator}
+      notLoadedMessage="Enter search query to show results"
     />);
   }
 }


### PR DESCRIPTION
New message  does not misleadingly refer to filters.

Fixes UISE-81.