### PR TITLE
Minor change in <AppIcon> implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Bump stripes-components dependency to `^3.0.7`, pulling in the STCOM-321 regression fix, which makes ISSN searching work again. Fixes UISE-82. Available from v1.1.2.
 * Removed unused react-bootstrap dep that was pulling in an incompatible babel-runtime release. Refs FOLIO-1425.
 * Change default search-area message not to refer to selecting filter. Fixes UISE-81. Available from v1.1.3.
+* Updated AppIcon implementation in Search
 
 ## [1.1.0](https://github.com/folio-org/ui-search/tree/v1.1.0) (2017-12-05)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.0.0...v1.1.0)

--- a/src/Search.js
+++ b/src/Search.js
@@ -191,16 +191,14 @@ class Search extends React.Component {
   render() {
     const resultsFormatter = {
       source: x => (
-        <span>
-          <AppIcon
-            app={x.source === 'local' ? 'inventory' : 'eholdings'}
-            iconKey={x.source === 'local' ? 'instance' : 'app'}
-            size="small"
-          />
-          &nbsp;
-          &nbsp;
+        <AppIcon
+          app={x.source === 'local' ? 'inventory' : 'eholdings'}
+          iconKey={x.source === 'local' ? 'instance' : 'app'}
+          size="small"
+        >
           {x.source === 'local' ? 'Local' : 'KB'}
-        </span>),
+        </AppIcon>
+      ),
       contributor: x => (x.contributor || []).map(y => `'${y.name}'`).join(', '),
     };
 


### PR DESCRIPTION
It's now possible to pass content to the AppIcon using the `children` prop for a more consistent and RTL-compatible layout.

I have updated the implementation of `<AppIcon />` in this PR.