### PR TITLE
use current stripes-form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-search
 
+## 1.3.0 (IN PROGRESS)
+
+* Update to stripes-form 0.9.0. Refs STRIPES-555.
+
 ## 1.2.0 (https://github.com/folio-org/ui-search/tree/v1.2.0) (2018-09-12)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.1.0...v1.2.0)
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   },
   "dependencies": {
     "@folio/stripes-components": "^3.0.8",
-    "@folio/stripes-form": "^0.8.2",
+    "@folio/stripes-form": "^0.9.0",
     "@folio/stripes-smart-components": "^1.5.0",
     "classnames": "^2.2.5",
     "hashcode": "^1.0.3",


### PR DESCRIPTION
Because stripes-form has not been released as a v1.0.x package,
this means ^0.8.0 is effectively ~0.8.0, meaning those packages
are locked at 0.8.x, not 0.x.x as intended. stripes-form 0.8.0
pulled in an old version of stripes-components which pulled in
an old version of React which brought darkness upon the land.

Refs [STRIPES-555](https://issues.folio.org/browse/STRIPES-555)