### PR TITLE
Remove mocha and nightmare from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "scripts": {
     "start": "stripes serve",
     "lint": "eslint .",
-    "test": "(cd ../ui-testing; env FOLIO_UI_URL=http://localhost:8080 FOLIO_UI_WAIT_TIMEOUT=10000 yarn test-module -o --run=search)"
+    "test": "stripes test nightmare"
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^3.2.1",
@@ -85,7 +85,9 @@
     "babel-eslint": "^9.0.0",
     "eslint": "^5.5.0",
     "react": "^16.5.0",
-    "react-dom": "^16.5.0"
+    "react-dom": "^16.5.0",
+    "react-redux": "^5.0.7",
+    "redux": "^4.0.0"
   },
   "dependencies": {
     "lodash": "^4.17.4",
@@ -95,8 +97,6 @@
   },
   "peerDependencies": {
     "@folio/stripes": "^1.0.0",
-    "mocha": "^5.0.0",
-    "nightmare": "^2.10.0",
     "react": "*"
   }
 }

--- a/test/ui-testing/01-null.js
+++ b/test/ui-testing/01-null.js
@@ -1,4 +1,4 @@
-const { describe, it } = require('mocha');
+/* global it describe */
 
 module.exports.test = (context) => {
   describe('Testing apparatus', function nullTest() {

--- a/test/ui-testing/02-titleSearch.js
+++ b/test/ui-testing/02-titleSearch.js
@@ -1,6 +1,4 @@
-const Nightmare = require('nightmare');
-const { describe, it, before, after } = require('mocha');
-
+/* global it describe Nightmare before after */
 module.exports.test = (context) => {
   describe('Codex Search by title', function titleSearchTest() {
     const { config, helpers: { login, logout, openApp }, meta: { testVersion } } = context;


### PR DESCRIPTION
Noticed when running `yarn install` in `folio-org/platform-core` branch:
```
warning " > @folio/search@1.3.0" has unmet peer dependency "mocha@^5.0.0".
warning " > @folio/search@1.3.0" has unmet peer dependency "nightmare@^2.10.0".
```

I'm pretty sure these peer statements are needed.