### PR TITLE
Enable subject search for codex

### DIFF
--- a/src/Search.js
+++ b/src/Search.js
@@ -97,7 +97,7 @@ const availableIndexes = [
   { label: 'ISBN', value: 'identifier/type=isbn' },
   { label: 'ISSN', value: 'identifier/type=issn' },
   { label: 'Contributor', value: 'contributor', localOnly: true },
-  { label: 'Subject', value: 'subject', localOnly: true },
+  { label: 'Subject', value: 'subject' },
   { label: 'Classification', value: 'classification', localOnly: true },
   { label: 'Publisher', value: 'publisher' },
 ];


### PR DESCRIPTION
In https://github.com/folio-org/mod-codex-ekb/pull/72, we added support in mod-codex-ekb to be able to search by "subject"(https://issues.folio.org/browse/MODCXEKB-69) and return results through mod-codex-mux to ui-search. However, for user to search mod-codex-ekb from the UI based on "subject", we need to enable that. This PR addresses that issue. 