### PR TITLE
Turn on react-hot-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   "dependencies": {
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
+    "react-hot-loader": "^4.3.12",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Route from 'react-router-dom/Route';
 import Switch from 'react-router-dom/Switch';
+import { hot } from 'react-hot-loader';
 import Search from './Search';
 import Settings from './settings';
 
@@ -36,4 +37,4 @@ class Routing extends React.Component {
   }
 }
 
-export default Routing;
+export default hot(module)(Routing);


### PR DESCRIPTION
Setup for `stripes-core` took place in https://github.com/folio-org/stripes-core/pull/431.

Turns on hot reloading for this module.