### PR TITLE
Don't force source name to KB if source name is not local. 

### DIFF
--- a/src/Search.js
+++ b/src/Search.js
@@ -200,7 +200,7 @@ class Search extends React.Component {
           iconKey={x.source === 'local' ? 'instance' : 'app'}
           size="small"
         >
-          {x.source === 'local' ? 'Local' : 'KB'}
+          {x.source === 'local' ? 'Local' : x.source }
         </AppIcon>
       ),
       contributor: x => (x.contributor || []).map(y => `'${y.name}'`).join(', '),


### PR DESCRIPTION
If source is local display Local, otherwise display the source as sent back by the codex adapter. If we need display labels different to source name, perhaps we can add a label property to the codex schema.

Required so that sources other than "Local" and "KB" can be supported at least initially.