### PR TITLE
integration tests must accommodate MCL aria changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.6.0 [IN PROGRESS]
 
 * Move AppIcon import to `@folio/stripes/core`. Refs STCOM-411.
+* Update integration tests to accommodate MCL aria changes. Fixes UISE-102.
 
 ## [1.5.0](https://github.com/folio-org/ui-search/tree/v1.5.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.4.0...v1.5.0)


### PR DESCRIPTION
Changes to the aria attributes in MCL must be reflected in the
integration tests as well. These tests do not run and are not currently
in use. Refactoring them completely is beyond the scope of UISE-102, but
the work of incorporating the recent MCL updates is complete.

Refs [UISE-102](https://issues.folio.org/browse/UISE-102), [STCOM-365](https://issues.folio.org/browse/STCOM-365)