### PR TITLE
gracefully handle missing filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Translate column headers. Fixes UISE-107.
 * Gracefully handle missing filters. Refs UISE-110.
 
+
 ## [1.6.0](https://github.com/folio-org/ui-search/tree/v1.6.0) (2019-03-17)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.5.0...v1.6.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-search
 
+## 1.7.0 (IN PROGRESS)
+
+* Gracefully handle missing filters. Refs UISE-110.
+
 ## [1.6.0](https://github.com/folio-org/ui-search/tree/v1.6.0) (2019-03-17)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.5.0...v1.6.0)
 

--- a/src/Search/model/parseFiltersString.js
+++ b/src/Search/model/parseFiltersString.js
@@ -1,5 +1,5 @@
 export default function parseFiltersString(filters) {
-  if (filters.length === 0) {
+  if (!filters || filters.length === 0) {
     return undefined;
   }
 


### PR DESCRIPTION
When clicking out of ui-search to a result and then using the back
button to return to search results, the `parseFiltersString` function
would explode because, somehow, it doesn't receive any filters. I dunno
why; but that's a problem for a different day. The fix here is simply to
prevent it from exploding when it doesn't receive any filters.

Refs [UISE-110](https://issues.folio.org/browse/UISE-110)