### PR TITLE
UISE-122: Update stripes to v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.9.0...v1.10.0)
 
 * Update of translations
+* Update "stripes" to 'v3.0.0', "stripes-core" to '4.0.0' and "react-intl" to '2.9.0'. Refs UISE-122.
 
 ## [1.9.0](https://github.com/folio-org/ui-search/tree/v1.9.0) (2019-09-10)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.8.0...v1.9.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 ## 1.11.0 (IN PROGRESS)
 
 * Update eslint to v6.2.1
+* Update "stripes" to 'v3.0.0', "stripes-core" to '4.0.0' and "react-intl" to '2.9.0'. Refs UISE-122.
 
 ## [1.10.0](https://github.com/folio-org/ui-search/tree/v1.10.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.9.0...v1.10.0)
 
 * Update of translations
-* Update "stripes" to 'v3.0.0', "stripes-core" to '4.0.0' and "react-intl" to '2.9.0'. Refs UISE-122.
 
 ## [1.9.0](https://github.com/folio-org/ui-search/tree/v1.9.0) (2019-09-10)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.8.0...v1.9.0)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,4 +3,5 @@ buildNPM {
   runLint = 'yes'
   runSonarqube = true
   runTest = 'yes'
+  runTestOptions = '--karma.singleRun --karma.browsers ChromeDocker --karma.reporters mocha junit --coverage'
 }

--- a/package.json
+++ b/package.json
@@ -84,9 +84,9 @@
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.0.0",
-    "@folio/stripes": "^2.0.0",
+    "@folio/stripes": "^3.0.0",
     "@folio/stripes-cli": "^1.4.0",
-    "@folio/stripes-core": "^3.0.2",
+    "@folio/stripes-core": "^4.0.0",
     "babel-eslint": "^10.0.3",
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
@@ -102,12 +102,12 @@
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
     "react-hot-loader": "^4.3.12",
-    "react-intl": "^2.8.0",
+    "react-intl": "^2.9.0",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.0.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.0.0",
+    "@folio/stripes": "^3.0.0",
     "react": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "mocha": "^5.2.0",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
+    "react-router-dom": "^4.0.0",
     "react-redux": "^5.0.7",
     "redux": "^4.0.0",
     "sinon": "^7.2.3"
@@ -101,13 +102,13 @@
   "dependencies": {
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
-    "react-hot-loader": "^4.3.12",
-    "react-intl": "^2.9.0",
-    "react-router": "^4.2.0",
-    "react-router-dom": "^4.0.0"
+    "react-hot-loader": "^4.3.12"
   },
   "peerDependencies": {
     "@folio/stripes": "^3.0.0",
+    "react-intl": "^2.9.0",
+    "react-router": "^4.2.0",
+    "react-router-dom": "^4.0.0",
     "react": "*"
   }
 }


### PR DESCRIPTION
## Purpose:
Update 
`stripes` to `v3.0.0`, 
`stripes-core` to `4.0.0`,
`react-intl` to `2.9.0`

## Task:
[UISE-122](https://issues.folio.org/browse/UISE-122)

## Note:
Please, update your core `package.json`:
```javascript
"dependencies": {
    "@folio/stripes": "^3.0.0"
  },
  "resolutions": {
    "@folio/stripes": "^3.0.0"
  }
```