### PR TITLE
STRIPES-672: Purge `intlShape` in prep for `react-intl` `v4` migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-search
 
 ## 2.1.0 (IN PROGRESS)
+* Purge `intlShape` in prep for `react-intl` `v4` migration. Refs STRIPES-672.
 
 ## [2.0.0](https://github.com/folio-org/ui-search/tree/v1.10.0) (2020-03-12)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.10.0...v2.0.0)

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage, injectIntl } from 'react-intl';
 
 import { AppIcon, IntlConsumer } from '@folio/stripes/core';
 
@@ -47,7 +47,7 @@ class Search extends React.Component {
         log: PropTypes.func.isRequired,
       }).isRequired,
     }).isRequired,
-    intl: intlShape,
+    intl: PropTypes.object,
   }
 
   static manifest = Object.freeze({


### PR DESCRIPTION
## Purpose

Purge `intlShape` in prep for `react-intl` `v4` migration in the scope of the [STRIPES-672](https://issues.folio.org/browse/STRIPES-672).