### PR TITLE
STRIPES-672: Upgrade react-intl

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   },
   "peerDependencies": {
     "@folio/stripes": "^3.0.0",
-    "react-intl": "^2.9.0",
+    "react-intl": "^4.5.1",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.0.0",
     "react": "*"


### PR DESCRIPTION
## Purpose

Upgrade react-intl in prep for `react-intl` `v4` migration. Refs STRIPES-672.