### PR TITLE
UISE-199: No visible codex permissions makes using the codex in Edelweiss difficult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.1.0 (IN PROGRESS)
 * Purge `intlShape` in prep for `react-intl` `v4` migration. Refs STRIPES-672.
 * Update `stripes` to `v4.0.0`, `stripes-core` to `5.0.0` and added `react-intl` to dev dependencies. UISE-124.
-* Add codex subpermissions to `module.search.enabled` permission. UISE-119.
+* Add `ui-search.codexsearch` permission. UISE-119.
 
 ## [2.0.0](https://github.com/folio-org/ui-search/tree/v1.10.0) (2020-03-12)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.10.0...v2.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.1.0 (IN PROGRESS)
 * Purge `intlShape` in prep for `react-intl` `v4` migration. Refs STRIPES-672.
 * Update `stripes` to `v4.0.0`, `stripes-core` to `5.0.0` and added `react-intl` to dev dependencies. UISE-124.
+* Add codex subpermissions to `module.search.enabled` permission. UISE-119.
 
 ## [2.0.0](https://github.com/folio-org/ui-search/tree/v1.10.0) (2020-03-12)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.10.0...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -32,10 +32,53 @@
       {
         "permissionName": "module.search.enabled",
         "displayName": "UI: Codex Search module is enabled",
+        "visible": true
+      },
+      {
+        "permissionName": "ui-search.codex-mux.instances",
+        "visible": false,
+        "subPermissions": [
+          "codex-mux.instances.collection.get",
+          "codex-mux.instances.item.get",
+          "codex-mux.instances-sources.collection.get"
+        ]
+      },
+      {
+        "permissionName": "ui-search.codex-mux.packages",
+        "visible": false,
+        "subPermissions": [
+          "codex-mux.packages.collection.get",
+          "codex-mux.packages.item.get",
+          "codex-mux.packages-sources.collection.get"
+        ]
+      },
+      {
+        "permissionName": "ui-search.codex-ekb.instances",
+        "visible": false,
+        "subPermissions": [
+          "codex-ekb.instances.collection.get",
+          "codex-ekb.instances.item.get",
+          "codex-ekb.instances-sources.collection.get"
+        ]
+      },
+      {
+        "permissionName": "ui-search.codex-ekb.packages",
+        "visible": false,
+        "subPermissions": [
+          "codex-ekb.packages.collection.get",
+          "codex-ekb.packages.item.get",
+          "codex-ekb.packages-sources.collection.get"
+        ]
+      },
+      {
+        "permissionName": "ui-search.codexsearch",
+        "displayName": "Search: Can search using the Codex with all back-ends",
         "visible": true,
         "subPermissions": [
-          "codex-mux.all",
-          "codex-ekb.all"
+          "ui-search.codex-mux.instances",
+          "ui-search.codex-mux.packages",
+          "ui-search.codex-ekb.instances",
+          "ui-search.codex-ekb.packages"
         ]
       }
     ],

--- a/package.json
+++ b/package.json
@@ -32,7 +32,11 @@
       {
         "permissionName": "module.search.enabled",
         "displayName": "UI: Codex Search module is enabled",
-        "visible": true
+        "visible": true,
+        "subPermissions": [
+          "codex-mux.all",
+          "codex-ekb.all"
+        ]
       }
     ],
     "translations": {

--- a/translations/ui-search/en.json
+++ b/translations/ui-search/en.json
@@ -56,5 +56,7 @@
   "filters.languages.ger": "German",
   "filters.languages.chi": "Mandarin",
   "filters.languages.rus": "Russian",
-  "filters.languages.ara": "Arabic"
+  "filters.languages.ara": "Arabic",
+
+  "permission.codexsearch": "Search: Can search using the Codex with all back-ends"
 }


### PR DESCRIPTION
## Purpose
- Add `ui-search.codexsearch` permission to be able to assign Codex search permissions in the UI

## Issue
[UISE-119](https://issues.folio.org/projects/UISE/issues/UISE-119)