### PR TITLE
Release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Change history for ui-search
 
-## 2.1.0 (IN PROGRESS)
+## 3.1.0 (IN PROGRESS)
+
+## [3.0.0](https://github.com/folio-org/ui-search/tree/v3.0.0) (2020-06-11)
+[Full Changelog](https://github.com/folio-org/ui-search/compare/v2.0.0...v3.0.0)
 * Purge `intlShape` in prep for `react-intl` `v4` migration. Refs STRIPES-672.
 * Update `stripes` to `v4.0.0`, `stripes-core` to `5.0.0` and added `react-intl` to dev dependencies. UISE-124.
 * Add `ui-search.codexsearch` permission. UISE-119.
 * Prefer `stripes.actsAs` to the deprecated `stripes.type` in `package.json`. Refs STCOR-148.
+* Update translations
 
 ## [2.0.0](https://github.com/folio-org/ui-search/tree/v1.10.0) (2020-03-12)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v1.10.0...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/search",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Search across the Codex",
   "repository": "folio-org/ui-search",
   "publishConfig": {

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -28,7 +28,6 @@ import {
   filterConfig,
 } from './model';
 
-
 class Search extends React.Component {
   static propTypes = {
     resources: PropTypes.shape({
@@ -190,7 +189,6 @@ class Search extends React.Component {
         ...rest
       };
     });
-
 
     return (
       <div data-test-search>

--- a/src/Search/model/redirectParams.js
+++ b/src/Search/model/redirectParams.js
@@ -1,4 +1,3 @@
-
 function redirectParamsKB(record) {
   const obj = {
     _path: `/eholdings/titles/${record.id}`,
@@ -10,7 +9,6 @@ function redirectParamsKB(record) {
 
   return obj;
 }
-
 
 function redirectParamsLocal(record) {
   const obj = {
@@ -33,6 +31,5 @@ function redirectParams(record) {
     return null;
   }
 }
-
 
 export default redirectParams;

--- a/src/ViewRecord.js
+++ b/src/ViewRecord.js
@@ -51,7 +51,6 @@ function renderBody(record) {
   );
 }
 
-
 class ViewRecord extends React.Component {
   static propTypes = {
     paneWidth: PropTypes.string.isRequired,


### PR DESCRIPTION
## Purpose

Release ui-search v3.0.0. [Jira](https://issues.folio.org/browse/UISE-126)

## Approach

- Updated the version and CHENGELOG.md according to the [guide](https://github.com/folio-org/stripes/blob/master/doc/release-procedure.md)
- Fixed lint issues