### PR TITLE
Refactor to MirageJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-search
 
 ## 3.1.0 (IN PROGRESS)
+* Refactor to `miragejs` from `bigtest/mirage`
 
 ## [3.0.0](https://github.com/folio-org/ui-search/tree/v3.0.0) (2020-06-11)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v2.0.0...v3.0.0)

--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
   },
   "devDependencies": {
     "@bigtest/interactor": "^0.9.2",
-    "@bigtest/mirage": "^0.0.1",
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.0.0",
@@ -139,12 +138,15 @@
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
     "eslint": "^6.2.1",
+    "faker": "^4.1.0",
+    "inflected": "^2.0.4",
+    "miragejs": "^0.1.40",
     "mocha": "^5.2.0",
     "react": "^16.5.0",
-    "react-intl": "^4.5.3",
     "react-dom": "^16.5.0",
-    "react-router-dom": "^4.0.0",
+    "react-intl": "^4.5.3",
     "react-redux": "^5.0.7",
+    "react-router-dom": "^4.0.0",
     "redux": "^4.0.0",
     "sinon": "^7.2.3"
   },
@@ -155,9 +157,9 @@
   },
   "peerDependencies": {
     "@folio/stripes": "^4.0.0",
+    "react": "*",
     "react-intl": "^4.5.3",
     "react-router": "^4.2.0",
-    "react-router-dom": "^4.0.0",
-    "react": "*"
+    "react-router-dom": "^4.0.0"
   }
 }

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -6,7 +6,10 @@ export default function setupApplication({
   hasAllPerms = true
 } = {}) {
   setupStripesCore({
-    mirageOptions,
+    mirageOptions: {
+      serverType: 'miragejs',
+      ...mirageOptions
+    },
     scenarios,
     stripesConfig: {
       hasAllPerms

--- a/test/bigtest/network/factories/application.js
+++ b/test/bigtest/network/factories/application.js
@@ -1,4 +1,5 @@
-import { Factory, faker } from '@bigtest/mirage';
+import { Factory } from 'miragejs';
+import faker from 'faker';
 
 export default Factory.extend({
   id: () => faker.random.uuid()

--- a/test/bigtest/network/factories/codex-instance.js
+++ b/test/bigtest/network/factories/codex-instance.js
@@ -1,4 +1,4 @@
-import { faker } from '@bigtest/mirage';
+import faker from 'faker';
 
 import Factory from './application';
 

--- a/test/bigtest/network/index.js
+++ b/test/bigtest/network/index.js
@@ -1,4 +1,4 @@
-import { camelize } from '@bigtest/mirage';
+import { camelize, underscore } from 'inflected';
 
 // auto-import all mirage submodules
 const req = require.context('./', true, /\.js$/);
@@ -8,7 +8,7 @@ const modules = req.keys().reduce((acc, modulePath) => {
   const moduleName = moduleParts[2];
 
   if (moduleName) {
-    const moduleKey = camelize(moduleName.replace('.js', ''));
+    const moduleKey = camelize(underscore(moduleName.replace('.js', '')), false);
 
     return Object.assign(acc, {
       [moduleType]: {

--- a/test/bigtest/network/models/codex-instance.js
+++ b/test/bigtest/network/models/codex-instance.js
@@ -1,3 +1,3 @@
-import { Model } from '@bigtest/mirage';
+import { Model } from 'miragejs';
 
 export default Model.extend();

--- a/test/bigtest/network/serializers/application.js
+++ b/test/bigtest/network/serializers/application.js
@@ -1,3 +1,3 @@
-import { RestSerializer } from '@bigtest/mirage';
+import { RestSerializer } from 'miragejs';
 
 export default RestSerializer;


### PR DESCRIPTION
## Motivation
![Screen Shot 2020-07-14 at 4 57 15 PM](https://user-images.githubusercontent.com/29791650/87475647-25324e00-c5f3-11ea-91b6-6d53fdfacdf4.png)
This is part of an on-going initiative to completely migrate all of `folio-org` projects from `@bigtest/mirage` to `miragejs`.

[`@bigtest/mirage`](https://github.com/bigtestjs/mirage/) was originally a prototype to make `mirage` available to any framework, but it has since been archived in favor of [`miragejs`](https://miragejs.com/). The documentation for `miragejs` is not only prodigious for its extensive API docs but also for its tutorials and guides. Furthermore, it receives regular bug-fixes and maintenance releases in thanks to its extremely large and active community.

Previous PR: [@folio-org/ui-plugin-find-import-profile #58](https://github.com/folio-org/ui-plugin-find-import-profile/pull/58)
_Linking the previous pull request so that subsequent ones can be found tagged below._

<details>
<summary>Overview of progress at the time of the creation of this PR (in chronological order):</summary>
<br>
✅ <code>ui-checkin</code>
<br>
✅ <code>ui-checkout</code>
<br>
☑️ <code>ui-circulation</code>
<br>
☑️ <code>ui-calendar</code>
<br>
✅ <code>ui-agreements</code>
<br>
☑️ <code>ui-app-template</code>
<br>
☑️ <code>ui-inventory</code>
<br>
☑️ <code>ui-data-export</code>
<br>
✅ <code>ui-finc-config</code>
<br>
☑️ <code>ui-licenses</code>
<br>
☑️ <code>ui-erm-comparisons</code>
<br>
☑️ <code>ui-myprofile</code>
<br>
☑️ <code>ui-local-kb-admin</code>
<br>
☑️ <code>ui-marccat</code>
<br>
☑️ <code>ui-finc-select</code>
<br>
☑️ <code>ui-erm-usage</code>
<br>
☑️ <code>ui-notes</code>
<br>
☑️ <code>ui-oai-pmh</code>
<br>
☑️ <code>ui-plugin-find-user</code>
<br>
☑️ <code>ui-plugin-find-eresource</code>
<br>
☑️ <code>ui-plugin-find-package-title</code>
<br>
☑️ <code>ui-plugin-find-import-profile</code>
<br>
☑️ <code>ui-requests</code>
</details>

## Approach
- [x] Cloned, installed, and then ran tests to double check that the tests are passing before refactoring.
- [x] Removed `@bigtest/mirage` and added `inflected`, `faker`, and `miragejs`.
- [x] ESlint & ran tests after the refactor to confirm they all pass.
- [x] Updated CHANGELOG.