### PR TITLE
Release v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v3.0.0...v3.1.0)
 * Refactor to `miragejs` from `bigtest/mirage`
 * Increment `@folio/stripes` to `v5.0.0`, increment `react-intl` to `v5.7.0` UISE-127.
+* Update translations
 
 ## [3.0.0](https://github.com/folio-org/ui-search/tree/v3.0.0) (2020-06-11)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v2.0.0...v3.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change history for ui-search
 
-## 3.1.0 (IN PROGRESS)
+## 3.2.0 (IN PROGRESS)
+
+## [3.1.0](https://github.com/folio-org/ui-search/tree/v3.1.0) (2020-10-13)
+[Full Changelog](https://github.com/folio-org/ui-search/compare/v3.0.0...v3.1.0)
 * Refactor to `miragejs` from `bigtest/mirage`
 * Increment `@folio/stripes` to `v5.0.0`, increment `react-intl` to `v5.7.0` UISE-127.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/search",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Search across the Codex",
   "repository": "folio-org/ui-search",
   "publishConfig": {


### PR DESCRIPTION
## Purpose 
Release ui-search `v3.1.0`. [UISE-131](https://issues.folio.org/browse/UISE-131)

## Approach
* Updated `CHANGELOG.md` according to [release guidelines](https://github.com/folio-org/stripes/blob/master/doc/release-procedure.md).