### PR TITLE
UISE-136: Update stripes to v6.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 yarn.lock
 .DS_Store
 yarn-error.log
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-search
 
 ## 3.2.0 (IN PROGRESS)
+* Update `stripes` to `v6.0.0`. UISE-136.
 
 ## [3.1.0](https://github.com/folio-org/ui-search/tree/v3.1.0) (2020-10-13)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v3.0.0...v3.1.0)

--- a/package.json
+++ b/package.json
@@ -131,9 +131,9 @@
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.0.0",
-    "@folio/stripes": "^5.0.0",
+    "@folio/stripes": "^6.0.0",
     "@folio/stripes-cli": "^1.18.0",
-    "@folio/stripes-core": "^6.0.0",
+    "@folio/stripes-core": "^7.0.0",
     "babel-eslint": "^10.0.3",
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
@@ -145,7 +145,7 @@
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
     "react-intl": "^5.7.0",
-    "react-redux": "^5.0.7",
+    "react-redux": "^7.2.0",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.0",
     "sinon": "^7.2.3"
@@ -156,7 +156,7 @@
     "react-hot-loader": "^4.3.12"
   },
   "peerDependencies": {
-    "@folio/stripes": "^5.0.0",
+    "@folio/stripes": "^6.0.0",
     "react": "*",
     "react-intl": "^5.7.0",
     "react-router": "^5.2.0",


### PR DESCRIPTION
## Purpose
In the scope of [UISE-136](https://issues.folio.org/browse/UISE-136).
Bump the stripes dependency to version 6.0.0 in ui-search so UI can work with the latest changes from the modules there. Task also covers the update of stripes related dependencies which also should be updated after the stripes update.

