### PR TITLE
UISE-138: Update `stripes-cli` to `v2.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.2.0 (IN PROGRESS)
 * Update `stripes` to `v6.0.0`. UISE-136.
+* Update `stripes-cli` to `v2.0.0`. UISE-138.
 
 ## [3.1.0](https://github.com/folio-org/ui-search/tree/v3.1.0) (2020-10-13)
 [Full Changelog](https://github.com/folio-org/ui-search/compare/v3.0.0...v3.1.0)

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.0.0",
     "@folio/stripes": "^6.0.0",
-    "@folio/stripes-cli": "^1.18.0",
+    "@folio/stripes-cli": "^2.0.0",
     "@folio/stripes-core": "^7.0.0",
     "babel-eslint": "^10.0.3",
     "babel-polyfill": "^6.26.0",


### PR DESCRIPTION
## Purpose

Update `stripes-cli` to `v2.0.0` in the scope of the [UISE-138](https://issues.folio.org/browse/UISE-138).