### PR TITLE
correctly provide notLoadedMessage

### DIFF
--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
-import { FormattedMessage, injectIntl } from 'react-intl';
+import { injectIntl } from 'react-intl';
 
 import { AppIcon, IntlConsumer } from '@folio/stripes/core';
 

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -220,7 +220,7 @@ class Search extends React.Component {
               disableRecordCreation
               parentResources={this.props.resources}
               parentMutator={this.props.mutator}
-              notLoadedMessage={<FormattedMessage id="ui-search.notLoadedMessage" />}
+              notLoadedMessage={intl.formatMessage({ id: 'ui-search.notLoadedMessage' })}
             />
           )}
         </IntlConsumer>


### PR DESCRIPTION
`notLoadedMessage` must be a string and therefore must be passed to
`<SearchAndSort>` via `intl.formatMessage(...)` rather than
`<FormattedMessage ...>`.